### PR TITLE
Remove Nabar From root

### DIFF
--- a/app/components/dash-navbar.tsx
+++ b/app/components/dash-navbar.tsx
@@ -1,0 +1,90 @@
+import { Link, useLocation } from "@remix-run/react";
+
+export default function DashNavbar() {
+  const location = useLocation(); // Get current path
+
+  return (
+    <nav className="navbar navbar-expand-lg p-2 mb-2 bg-white fixed-top">
+      <div className="container-fluid">
+        {/* Brand */}
+        <Link className="navbar-brand" to="/">FindMe</Link>
+
+        {/* Offcanvas Toggle Button */}
+        <button
+          className="navbar-toggler"
+          type="button"
+          data-bs-toggle="offcanvas"
+          data-bs-target="#offcanvasNavbar"
+          aria-controls="offcanvasNavbar"
+          aria-label="Toggle navigation"
+        >
+          <span className="navbar-toggler-icon"></span>
+        </button>
+
+        {/* Offcanvas Sidebar */}
+        <div
+          className="offcanvas offcanvas-end"
+          tabIndex={-1}
+          data-bs-scroll="true"
+          id="offcanvasNavbar"
+          aria-labelledby="offcanvasNavbarLabel"
+        >
+          <div className="offcanvas-header">
+            <h5 className="offcanvas-title" id="offcanvasNavbarLabel">FindMe</h5>
+            <button
+              type="button"
+              className="btn-close"
+              data-bs-dismiss="offcanvas"
+              aria-label="Close"
+            ></button>
+          </div>
+
+          <div className="offcanvas-body">
+            <ul className="navbar-nav me-auto mb-2 mb-lg-0">
+              <li className="nav-item fw-bold">
+                <Link prefetch="intent" className={`nav-link ${location.pathname === "/" ? "active" : ""}`} to="/">
+                  Missing Persons
+                </Link>
+              </li>
+              <li className="nav-item fw-bold">
+                <Link prefetch="intent" className={`nav-link ${location.pathname === "/unidentified" ? "active" : ""}`} to="/unidentified">
+                  Unidentified Persons
+                </Link>
+              </li>
+              <li className="nav-item fw-bold">
+                <Link prefetch="intent" className={`nav-link ${location.pathname === "/unclaimed" ? "active" : ""}`} to="/unclaimed">
+                  Unclaimed Persons
+                </Link>
+              </li>
+            </ul>
+
+            {/* New Report Button */}
+            <Link prefetch="intent" className="btn btn-primary me-3" to="/new-report">Report Missing Person</Link>
+
+            {/* Language Dropdown, Register & Login */}
+            <ul className="navbar-nav">
+              <li className="nav-item dropdown">
+                <Link
+                  className="nav-link dropdown-toggle"
+                  to="#"
+                  role="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                >
+                  Language
+                </Link>
+                <ul className="dropdown-menu">
+                  <li><Link className="dropdown-item" to="#">English</Link></li>
+                  <li><Link className="dropdown-item" to="#">Swahili</Link></li>
+                </ul>
+              </li>
+              <li className="nav-item">
+                <Link prefetch="intent" className="nav-link" to="/login">Logout</Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,7 +9,6 @@ import { useEffect } from "react";
 import type { LinksFunction } from "@remix-run/node";
 
 import Footer from "~/components/footer"; // Import Footer
-import Navbar from "~/components/navbar"; // Import Navbar
 
 
 // Import Bootstrap CSS
@@ -40,8 +39,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links /> {/* Remix will inject styles from `links()` here */}
       </head>
       <body className="bg-dark text-white d-flex flex-column min-vh-100">
-        
-        <Navbar />
 
         {/* Page Content */}
         <main className="flex-grow-1">

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,5 +1,6 @@
 import type { MetaFunction, LoaderFunction} from "@remix-run/node";
 import { useEffect } from "react";
+import Navbar from "~/components/navbar"; // Import Navbar
 import "datatables.net-bs5"; // Import Bootstrap 5 DataTables
 import DataTable from "datatables.net";
 import { useLoaderData } from "@remix-run/react";
@@ -53,6 +54,8 @@ export default function MissingPersonsTable() {
   }, []);
 
   return (
+    <>
+    <Navbar />
     <div className="container mt-5">
       <div className="table-responsive"> {/* Ensures the table is scrollable on small screens */}
       <h2 className="mt-5">Missing Persons</h2>
@@ -108,6 +111,7 @@ export default function MissingPersonsTable() {
       </table>
       </div>
     </div>
+    </>
   );
 }
 

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@remix-run/react";
 import { useState } from "react";
+import DashNavbar from "~/components/dash-navbar"; // Import Navbar
 
 // Mock Data (Replace with API Calls Later)
 const user = { name: "John Doe", lastLogin: "2025-03-20 14:32" };
@@ -12,6 +13,8 @@ export default function Dashboard() {
   const [darkMode, setDarkMode] = useState(false);
 
   return (
+    <>
+    <DashNavbar />
     <div  className={`container py-5 mt-5 ${darkMode ? "bg-dark text-light" : ""}`}>
       {/* Header */}
       <div className="d-flex justify-content-between align-items-center mb-4">
@@ -97,5 +100,6 @@ export default function Dashboard() {
         )}
       </div>
     </div>
+    </>
   );
 }

--- a/app/routes/forgot-password.tsx
+++ b/app/routes/forgot-password.tsx
@@ -1,8 +1,11 @@
 import { Link } from '@remix-run/react';
+import Navbar from "~/components/navbar"; // Import Navbar
 // import React from 'react';  // Uncomment if using hooks
 
 const ForgotPassword = () => {
   return (
+    <>
+    <Navbar />
     <div className="d-flex justify-content-center align-items-center vh-100" style={{ backgroundColor: "#212529" }}>
       <div className="card p-4" style={{ minWidth: '300px', maxWidth: '400px', backgroundColor: '#343a40', color: 'white' }}>
         <h3 className="text-center mb-4">Forgot Password</h3>
@@ -18,6 +21,7 @@ const ForgotPassword = () => {
         </div>
       </div>
     </div>
+    </>
   );
 };
 

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,8 +1,11 @@
 import { Link } from '@remix-run/react';
+import Navbar from "~/components/navbar"; // Import Navbar
 // import React from 'react';  // If you plan to use hooks like useState, useEffect, etc., then you’ll need to import React.
 
 const Login = () => {
   return (
+    <>
+    <Navbar/>
     <div className="d-flex justify-content-center align-items-center vh-100" style={{ backgroundColor: "#212529" }}>
       <div className="card p-4" style={{ minWidth: '300px', maxWidth: '400px', backgroundColor: '#343a40', color: 'white' }}>
         <h3 className="text-center mb-4">Login</h3>
@@ -23,6 +26,7 @@ const Login = () => {
         </form>
       </div>
     </div>
+    </>
   );
 };
 

--- a/app/routes/new-report.tsx
+++ b/app/routes/new-report.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import Navbar from "~/components/navbar"; // Import Navbar
 import { supabase } from "~/utils/supabaseClient"; // Get the supabaseclient
 import { json } from "@remix-run/react";
 import { useFetcher } from "@remix-run/react";
@@ -62,6 +63,8 @@ export default function NewReportForm() {
   const today = new Date().toISOString().split("T")[0];
 
   return (
+    <>
+    <Navbar />
     <div className="container pt-5 mt-5">
       <h2 className="mb-4">New Missing Person Report</h2>
       <fetcher.Form method="post">
@@ -175,5 +178,6 @@ export default function NewReportForm() {
         {fetcher.data?.error && <p className="text-danger mt-3">Error: {fetcher.data.error}</p>}
       </fetcher.Form>
     </div>
+    </>
   );
 }

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -1,4 +1,5 @@
 import { useActionData, Form, Link, useNavigation } from "@remix-run/react";
+import Navbar from "~/components/navbar"; // Import Navbar
 import { ActionFunctionArgs, redirect, json } from "@remix-run/node";
 import { supabase } from "~/utils/supabaseClient"; // Server-side Supabase client
 
@@ -67,6 +68,8 @@ export default function Register() {
   const isSubmitting = navigation.state === "submitting";
 
   return (
+    <>
+    <Navbar />
     <div className="d-flex justify-content-center align-items-center vh-100" style={{ backgroundColor: "#212529" }}>
       <div className="card p-4" style={{ minWidth: '400px', maxWidth: '400px', backgroundColor: '#343a40', color: 'white' }}>
         <h3 className="text-center mb-4">Register</h3>
@@ -98,5 +101,6 @@ export default function Register() {
         </Form>
       </div>
     </div>
+    </>
   );
 }

--- a/app/routes/unclaimed.tsx
+++ b/app/routes/unclaimed.tsx
@@ -1,5 +1,6 @@
 import type { MetaFunction, LoaderFunction } from "@remix-run/node";
 import { useEffect } from "react";
+import Navbar from "~/components/navbar"; // Import Navbar
 import "datatables.net-bs5"; // Import Bootstrap 5 DataTables
 import DataTable from "datatables.net";
 import { useLoaderData } from "@remix-run/react";
@@ -52,6 +53,8 @@ export default function UnclaimedPersonsTable() {
   }, []);
 
   return (
+    <>
+     <Navbar />
     <div className="container mt-5">
       <div className="table-responsive"> {/* Ensures the table is scrollable on small screens */}
       <h2 className="mt-5">Unclaimed Persons</h2>
@@ -109,5 +112,6 @@ export default function UnclaimedPersonsTable() {
       </table>
       </div>
     </div>
+    </>
   );
 }

--- a/app/routes/unidentified.tsx
+++ b/app/routes/unidentified.tsx
@@ -1,5 +1,6 @@
 import type { MetaFunction, LoaderFunction } from "@remix-run/node";
 import { useEffect } from "react";
+import Navbar from "~/components/navbar"; // Import Navbar
 import "datatables.net-bs5"; // Import Bootstrap 5 DataTables
 import DataTable from "datatables.net";
 import { useLoaderData } from "@remix-run/react";
@@ -51,6 +52,8 @@ export default function UnidentifiedPersonsTable() {
   }, []);
 
   return (
+    <>
+    <Navbar />
     <div className="container mt-5">
       <div className="table-responsive"> {/* Ensures the table is scrollable on small screens */}
       <h2 className="mt-5">Unidentifed Persons</h2>
@@ -102,6 +105,7 @@ export default function UnidentifiedPersonsTable() {
       </table>
       </div>
     </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Moving the navbar component from the root. This will ensure the navbar can be imported dynamically as required by different pages. It also give opportunity to utilize different navabars for different pages. Also creating a dahnavbar for the user dashboard.